### PR TITLE
added ethAsset2Waves, a function that converts a token's eth standard…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,30 @@
 {
-  "name": "@waves/node-api-js",
-  "version": "1.3.10",
+  "name": "@better2better/waves-node-api-js",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@waves/node-api-js",
-      "version": "1.3.10",
+      "name": "@better2better/waves-node-api-js",
+      "version": "1.4.0",
       "dependencies": {
+        "@noble/hashes": "^1.8.0",
         "@types/node-fetch": "^2.5.4",
         "@waves/bignumber": "^1.1.1",
+        "@waves/ts-lib-crypto": "^1.4.4-beta.1",
         "@waves/ts-types": "1.2.0",
         "node-fetch": "^2.6.7",
         "typed-ts-events": "^1.1.1"
       },
       "devDependencies": {
         "@types/jest": "^26.0.23",
+        "@types/node": "^22.15.30",
         "@waves/node-state": "0.1.0",
-        "@waves/waves-transactions": "4.3.10-beta.1",
+        "@waves/waves-transactions": "4.3.10",
         "jest": "^26.6.3",
         "ts-jest": "^26.5.6",
         "ts-loader": "^7.0.5",
-        "typescript": "^3.9.4",
+        "typescript": "^5.8.3",
         "webpack": "^4.46.0",
         "webpack-cli": "^4.9.2"
       }
@@ -1804,35 +1807,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -1842,31 +1862,36 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -1993,9 +2018,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.40.tgz",
-      "integrity": "sha512-UXdBxNGqTMtm7hCwh9HtncFVLrXoqA3oJW30j6XWp5BH/wu3mVeaxo7cq5benFdBw34HB3XDT2TRPI7rXZ+mDg=="
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.4",
@@ -2053,14 +2082,14 @@
       }
     },
     "node_modules/@waves/node-api-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@waves/node-api-js/-/node-api-js-1.3.0.tgz",
-      "integrity": "sha512-FEI42KM1C6hE541kexV/eqWDeBrVxeMswZbHQ9kRlFdso/kKmouhhjV73NI/zFCSwMzbFI4YDe2ElOSim0DyEA==",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@waves/node-api-js/-/node-api-js-1.3.10.tgz",
+      "integrity": "sha512-P3hQiw8K27tVt6S1MEnKejcPEaHbpPjW6NAn6wrT+9anuh1BTmjJPnuqwaU8WrLEC4faYBgssnhF8JsX5MrkvA==",
       "dev": true,
       "dependencies": {
         "@types/node-fetch": "^2.5.4",
         "@waves/bignumber": "^1.1.1",
-        "@waves/ts-types": "^1.0.12",
+        "@waves/ts-types": "1.2.0",
         "node-fetch": "^2.6.7",
         "typed-ts-events": "^1.1.1"
       }
@@ -2085,39 +2114,8 @@
         "node-state": "dist/cli.js"
       }
     },
-    "node_modules/@waves/node-state/node_modules/@waves/protobuf-serialization": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@waves/protobuf-serialization/-/protobuf-serialization-1.4.3.tgz",
-      "integrity": "sha512-qloPEDn9FsiZWLX8y7CWQXXxX+RGq1zPN5AaYmOBrrZ5Z8EA4hoTVINkQFpl2VbfSpRjI5XpwsxbkL3QhgCodw==",
-      "dev": true,
-      "dependencies": {
-        "@types/long": "^4.0.0",
-        "protobufjs": "^6.8.8"
-      }
-    },
     "node_modules/@waves/node-state/node_modules/@waves/ts-types": {
       "version": "1.0.2",
-      "dev": true
-    },
-    "node_modules/@waves/node-state/node_modules/@waves/waves-transactions": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@waves/waves-transactions/-/waves-transactions-4.2.10.tgz",
-      "integrity": "sha512-sXhZ9XLPK21SAW0s8d92hIh9YwcZy2jMD3wGIbnrmZzLjowPWsFZ0CA1x6fCSMIA9O8jFgq0TUHDvZEgg98Bng==",
-      "dev": true,
-      "dependencies": {
-        "@waves/marshall": "^0.15.0-beta.1",
-        "@waves/node-api-js": "^1.2.10",
-        "@waves/protobuf-serialization": "1.4.3",
-        "@waves/ts-lib-crypto": "1.4.3",
-        "@waves/ts-types": "1.1.0",
-        "axios": "^0.19.0",
-        "long": "^4.0.0"
-      }
-    },
-    "node_modules/@waves/node-state/node_modules/@waves/waves-transactions/node_modules/@waves/ts-types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@waves/ts-types/-/ts-types-1.1.0.tgz",
-      "integrity": "sha512-SGHj4cIIvMAhDPiDhbpEzP2UqNF3VgTssGf6UaJ7vwzxq0W1pqz2lKMDe9pZup9p9rEETGW4Yy3+K1G7OGOLxA==",
       "dev": true
     },
     "node_modules/@waves/node-state/node_modules/ansi-regex": {
@@ -2261,22 +2259,24 @@
       "dev": true
     },
     "node_modules/@waves/protobuf-serialization": {
-      "version": "1.5.1-beta.2",
-      "resolved": "https://registry.npmjs.org/@waves/protobuf-serialization/-/protobuf-serialization-1.5.1-beta.2.tgz",
-      "integrity": "sha512-tQc6YUppZ4sX8jOlR5+asujmc4RjCXZ++SGUS7rRbdBD4MDFnM/OKnbXSIAc8cWDoqvGMiGInfJnd35QJ/1EOw==",
-      "dev": true,
-      "dependencies": {
-        "@types/long": "^4.0.0",
-        "protobufjs": "6.10.3"
-      }
-    },
-    "node_modules/@waves/ts-lib-crypto": {
-      "version": "1.4.3",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@waves/protobuf-serialization/-/protobuf-serialization-1.5.2.tgz",
+      "integrity": "sha512-oqgjP9P8AWhj8vDQW7aXYSYP+67g311vFDsY0oddMJvTJ+hvSM6rRG2y7H8KE1dekTUwp6cyRCNlsw2KueEk7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/long": "^4.0.0",
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "node_modules/@waves/ts-lib-crypto": {
+      "version": "1.4.4-beta.1",
+      "resolved": "https://registry.npmjs.org/@waves/ts-lib-crypto/-/ts-lib-crypto-1.4.4-beta.1.tgz",
+      "integrity": "sha512-tlvThkMCoCDicOznW82wDZWQqfAWcm6ulQnuNzR++X9o0EOHM3Cj8LlS2pkgF0YjZrqEYHTp/4e0RXXYVY+dpw==",
+      "license": "MIT",
+      "dependencies": {
         "js-sha3": "^0.8.0",
-        "node-forge": "^0.8.5"
+        "node-forge": "^0.10.0"
       }
     },
     "node_modules/@waves/ts-types": {
@@ -2285,25 +2285,41 @@
       "integrity": "sha512-ddb0wTZj1Onh5CaQNTg0d7ivjKSaTymcJ0fwuEzLoEypuS9g5soJpbWIF+GApduxWt4lksXqaZjEJIU2EFTdeQ=="
     },
     "node_modules/@waves/waves-transactions": {
-      "version": "4.3.10-beta.1",
-      "resolved": "https://registry.npmjs.org/@waves/waves-transactions/-/waves-transactions-4.3.10-beta.1.tgz",
-      "integrity": "sha512-Wn6AlA2kwlA07JlTaykVNyFo8W2FYSI/B41sdjnLs3CVSeR3uyo9z9pRkx3Rf2lj/eR4Nup8y4fUzdreOQq5bA==",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/@waves/waves-transactions/-/waves-transactions-4.3.10.tgz",
+      "integrity": "sha512-Wx87hoahNd4/t21GzC9zMIkKiC+l20o4jjKQEyTQWksGk6arTe70GpTEKNbdWgRWhFRTjJpGtIKlDdKzf220KA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@waves/marshall": "^0.15.0-beta.1",
-        "@waves/node-api-js": "^1.2.10",
-        "@waves/protobuf-serialization": "1.5.1-beta.2",
+        "@waves/node-api-js": "^1.3.10",
+        "@waves/protobuf-serialization": "1.5.2",
         "@waves/ts-lib-crypto": "1.4.3",
-        "@waves/ts-types": "1.2.0-beta.2",
+        "@waves/ts-types": "1.2.0",
         "axios": "^0.19.0",
         "long": "^4.0.0"
       }
     },
-    "node_modules/@waves/waves-transactions/node_modules/@waves/ts-types": {
-      "version": "1.2.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@waves/ts-types/-/ts-types-1.2.0-beta.2.tgz",
-      "integrity": "sha512-ya8LP5HYq0qaIoJbS2T10+skUPqKtXCEJsvLNZQ0hwdW4RYRE1zNrWd7hcVaeGxawOSpCcDY+mxVjBYPcojkoQ==",
-      "dev": true
+    "node_modules/@waves/waves-transactions/node_modules/@waves/ts-lib-crypto": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@waves/ts-lib-crypto/-/ts-lib-crypto-1.4.3.tgz",
+      "integrity": "sha512-2pKgyvtLapgM5vpaUEYzX7NYe2bkB+HdWn9W/4d7UFKwyg6zoOYhRQWyb6GuLi3OLHTETgiqpcMZvciFA0Ds6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-sha3": "^0.8.0",
+        "node-forge": "^0.8.5"
+      }
+    },
+    "node_modules/@waves/waves-transactions/node_modules/node-forge": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 4.5.0"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -8945,7 +8961,6 @@
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -9535,11 +9550,12 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "0.8.5",
-      "dev": true,
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
-        "node": ">= 4.5.0"
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/node-int64": {
@@ -10130,11 +10146,12 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.3.tgz",
-      "integrity": "sha512-yvAslS0hNdBhlSKckI4R1l7wunVilX66uvrjzE4MimiAt7/qw1nLpMhZrn/ObuUTM/c3Xnfl01LYMdcSJe6dwg==",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -10147,19 +10164,13 @@
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
         "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
+        "@types/node": ">=13.7.0",
         "long": "^4.0.0"
       },
       "bin": {
         "pbjs": "bin/pbjs",
         "pbts": "bin/pbts"
       }
-    },
-    "node_modules/protobufjs/node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
-      "dev": true
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -11874,7 +11885,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.9",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -11882,8 +11895,14 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/union-value": {
       "version": "1.0.1",
@@ -14096,6 +14115,11 @@
         }
       }
     },
+    "@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -14271,9 +14295,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.40.tgz",
-      "integrity": "sha512-UXdBxNGqTMtm7hCwh9HtncFVLrXoqA3oJW30j6XWp5BH/wu3mVeaxo7cq5benFdBw34HB3XDT2TRPI7rXZ+mDg=="
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/node-fetch": {
       "version": "2.5.4",
@@ -14324,14 +14351,14 @@
       }
     },
     "@waves/node-api-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@waves/node-api-js/-/node-api-js-1.3.0.tgz",
-      "integrity": "sha512-FEI42KM1C6hE541kexV/eqWDeBrVxeMswZbHQ9kRlFdso/kKmouhhjV73NI/zFCSwMzbFI4YDe2ElOSim0DyEA==",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@waves/node-api-js/-/node-api-js-1.3.10.tgz",
+      "integrity": "sha512-P3hQiw8K27tVt6S1MEnKejcPEaHbpPjW6NAn6wrT+9anuh1BTmjJPnuqwaU8WrLEC4faYBgssnhF8JsX5MrkvA==",
       "dev": true,
       "requires": {
         "@types/node-fetch": "^2.5.4",
         "@waves/bignumber": "^1.1.1",
-        "@waves/ts-types": "^1.0.12",
+        "@waves/ts-types": "1.2.0",
         "node-fetch": "^2.6.7",
         "typed-ts-events": "^1.1.1"
       }
@@ -14352,42 +14379,9 @@
         "yargs": "^17.0.1"
       },
       "dependencies": {
-        "@waves/protobuf-serialization": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/@waves/protobuf-serialization/-/protobuf-serialization-1.4.3.tgz",
-          "integrity": "sha512-qloPEDn9FsiZWLX8y7CWQXXxX+RGq1zPN5AaYmOBrrZ5Z8EA4hoTVINkQFpl2VbfSpRjI5XpwsxbkL3QhgCodw==",
-          "dev": true,
-          "requires": {
-            "@types/long": "^4.0.0",
-            "protobufjs": "^6.8.8"
-          }
-        },
         "@waves/ts-types": {
           "version": "1.0.2",
           "dev": true
-        },
-        "@waves/waves-transactions": {
-          "version": "4.2.10",
-          "resolved": "https://registry.npmjs.org/@waves/waves-transactions/-/waves-transactions-4.2.10.tgz",
-          "integrity": "sha512-sXhZ9XLPK21SAW0s8d92hIh9YwcZy2jMD3wGIbnrmZzLjowPWsFZ0CA1x6fCSMIA9O8jFgq0TUHDvZEgg98Bng==",
-          "dev": true,
-          "requires": {
-            "@waves/marshall": "^0.15.0-beta.1",
-            "@waves/node-api-js": "^1.2.10",
-            "@waves/protobuf-serialization": "1.4.3",
-            "@waves/ts-lib-crypto": "1.4.3",
-            "@waves/ts-types": "1.1.0",
-            "axios": "^0.19.0",
-            "long": "^4.0.0"
-          },
-          "dependencies": {
-            "@waves/ts-types": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/@waves/ts-types/-/ts-types-1.1.0.tgz",
-              "integrity": "sha512-SGHj4cIIvMAhDPiDhbpEzP2UqNF3VgTssGf6UaJ7vwzxq0W1pqz2lKMDe9pZup9p9rEETGW4Yy3+K1G7OGOLxA==",
-              "dev": true
-            }
-          }
         },
         "ansi-regex": {
           "version": "5.0.0",
@@ -14483,21 +14477,22 @@
       "dev": true
     },
     "@waves/protobuf-serialization": {
-      "version": "1.5.1-beta.2",
-      "resolved": "https://registry.npmjs.org/@waves/protobuf-serialization/-/protobuf-serialization-1.5.1-beta.2.tgz",
-      "integrity": "sha512-tQc6YUppZ4sX8jOlR5+asujmc4RjCXZ++SGUS7rRbdBD4MDFnM/OKnbXSIAc8cWDoqvGMiGInfJnd35QJ/1EOw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@waves/protobuf-serialization/-/protobuf-serialization-1.5.2.tgz",
+      "integrity": "sha512-oqgjP9P8AWhj8vDQW7aXYSYP+67g311vFDsY0oddMJvTJ+hvSM6rRG2y7H8KE1dekTUwp6cyRCNlsw2KueEk7g==",
       "dev": true,
       "requires": {
         "@types/long": "^4.0.0",
-        "protobufjs": "6.10.3"
+        "protobufjs": "^6.8.8"
       }
     },
     "@waves/ts-lib-crypto": {
-      "version": "1.4.3",
-      "dev": true,
+      "version": "1.4.4-beta.1",
+      "resolved": "https://registry.npmjs.org/@waves/ts-lib-crypto/-/ts-lib-crypto-1.4.4-beta.1.tgz",
+      "integrity": "sha512-tlvThkMCoCDicOznW82wDZWQqfAWcm6ulQnuNzR++X9o0EOHM3Cj8LlS2pkgF0YjZrqEYHTp/4e0RXXYVY+dpw==",
       "requires": {
         "js-sha3": "^0.8.0",
-        "node-forge": "^0.8.5"
+        "node-forge": "^0.10.0"
       }
     },
     "@waves/ts-types": {
@@ -14506,24 +14501,34 @@
       "integrity": "sha512-ddb0wTZj1Onh5CaQNTg0d7ivjKSaTymcJ0fwuEzLoEypuS9g5soJpbWIF+GApduxWt4lksXqaZjEJIU2EFTdeQ=="
     },
     "@waves/waves-transactions": {
-      "version": "4.3.10-beta.1",
-      "resolved": "https://registry.npmjs.org/@waves/waves-transactions/-/waves-transactions-4.3.10-beta.1.tgz",
-      "integrity": "sha512-Wn6AlA2kwlA07JlTaykVNyFo8W2FYSI/B41sdjnLs3CVSeR3uyo9z9pRkx3Rf2lj/eR4Nup8y4fUzdreOQq5bA==",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/@waves/waves-transactions/-/waves-transactions-4.3.10.tgz",
+      "integrity": "sha512-Wx87hoahNd4/t21GzC9zMIkKiC+l20o4jjKQEyTQWksGk6arTe70GpTEKNbdWgRWhFRTjJpGtIKlDdKzf220KA==",
       "dev": true,
       "requires": {
         "@waves/marshall": "^0.15.0-beta.1",
-        "@waves/node-api-js": "^1.2.10",
-        "@waves/protobuf-serialization": "1.5.1-beta.2",
+        "@waves/node-api-js": "^1.3.10",
+        "@waves/protobuf-serialization": "1.5.2",
         "@waves/ts-lib-crypto": "1.4.3",
-        "@waves/ts-types": "1.2.0-beta.2",
+        "@waves/ts-types": "1.2.0",
         "axios": "^0.19.0",
         "long": "^4.0.0"
       },
       "dependencies": {
-        "@waves/ts-types": {
-          "version": "1.2.0-beta.2",
-          "resolved": "https://registry.npmjs.org/@waves/ts-types/-/ts-types-1.2.0-beta.2.tgz",
-          "integrity": "sha512-ya8LP5HYq0qaIoJbS2T10+skUPqKtXCEJsvLNZQ0hwdW4RYRE1zNrWd7hcVaeGxawOSpCcDY+mxVjBYPcojkoQ==",
+        "@waves/ts-lib-crypto": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/@waves/ts-lib-crypto/-/ts-lib-crypto-1.4.3.tgz",
+          "integrity": "sha512-2pKgyvtLapgM5vpaUEYzX7NYe2bkB+HdWn9W/4d7UFKwyg6zoOYhRQWyb6GuLi3OLHTETgiqpcMZvciFA0Ds6g==",
+          "dev": true,
+          "requires": {
+            "js-sha3": "^0.8.0",
+            "node-forge": "^0.8.5"
+          }
+        },
+        "node-forge": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+          "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
           "dev": true
         }
       }
@@ -19096,8 +19101,7 @@
       }
     },
     "js-sha3": {
-      "version": "0.8.0",
-      "dev": true
+      "version": "0.8.0"
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -19531,8 +19535,9 @@
       }
     },
     "node-forge": {
-      "version": "0.8.5",
-      "dev": true
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -19935,9 +19940,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.3.tgz",
-      "integrity": "sha512-yvAslS0hNdBhlSKckI4R1l7wunVilX66uvrjzE4MimiAt7/qw1nLpMhZrn/ObuUTM/c3Xnfl01LYMdcSJe6dwg==",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -19951,16 +19956,8 @@
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
         "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
+        "@types/node": ">=13.7.0",
         "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
-          "dev": true
-        }
       }
     },
     "prr": {
@@ -21150,8 +21147,15 @@
       }
     },
     "typescript": {
-      "version": "3.9.9",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,17 +1,28 @@
 {
-  "name": "@waves/node-api-js",
-  "version": "1.3.10",
+  "name": "@better2better/waves-node-api-js",
+  "description": "JavaScript/TypeScript library for interacting with the Waves Node API.",
+  "author": {
+    "name": "Better2Better",
+    "email": "contact@better2better.tech",
+    "url": "https://better2better.tech"
+  },
+  "version": "1.4.1",
   "main": "cjs/index.js",
   "types": "cjs/index.d.ts",
   "scripts": {
     "testCommand": "jest",
     "prepare": "npm run build",
-    "build": "tsc -p ./tsconfig-es.json && tsc -p ./tsconfig-cjs.json && webpack",
+    "build": "set NODE_OPTIONS=--openssl-legacy-provider && tsc -p ./tsconfig-es.json && tsc -p ./tsconfig-cjs.json && webpack",
     "test": "node-state -e -n -m typescript -o ./test/_state.ts -r"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
+    "@noble/hashes": "^1.8.0",
     "@types/node-fetch": "^2.5.4",
     "@waves/bignumber": "^1.1.1",
+    "@waves/ts-lib-crypto": "^1.4.4-beta.1",
     "@waves/ts-types": "1.2.0",
     "node-fetch": "^2.6.7",
     "typed-ts-events": "^1.1.1"
@@ -54,12 +65,13 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
+    "@types/node": "^22.15.30",
     "@waves/node-state": "0.1.0",
     "@waves/waves-transactions": "4.3.10",
     "jest": "^26.6.3",
     "ts-jest": "^26.5.6",
     "ts-loader": "^7.0.5",
-    "typescript": "^3.9.4",
+    "typescript": "^5.8.3",
     "webpack": "^4.46.0",
     "webpack-cli": "^4.9.2"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import wavesAddress2eth from "./tools/adresses/wavesAddress2eth";
 import ethAddress2waves from "./tools/adresses/ethAddress2waves";
 import wavesAsset2Eth from "./tools/assets/wavesAsset2eth";
+import ethAsset2Waves from "./tools/assets/ethAsset2waves";
 import ethTxId2waves from "./tools/transactions/ethTxId2waves";
 
 import { create as createFn } from './create';
@@ -9,6 +10,7 @@ export {
     wavesAddress2eth,
     ethAddress2waves,
     wavesAsset2Eth,
+    ethAsset2Waves,
     ethTxId2waves
 };
 

--- a/src/tools/assets/ethAsset2waves.ts
+++ b/src/tools/assets/ethAsset2waves.ts
@@ -2,18 +2,40 @@ import { base58Encode } from '@waves/ts-lib-crypto';
 import { keccak_256 } from '@noble/hashes/sha3';
 import { blake2b } from '@noble/hashes/blake2b';
 
+// Função para converter hexadecimal para Uint8Array
+function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error("Invalid hex string");
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+// Função para concatenar Uint8Arrays
+function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+  const totalLength = arrays.reduce((sum, arr) => sum + arr.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(arr, offset);
+    offset += arr.length;
+  }
+  return result;
+}
+
 export default function ethAsset2Waves(ethAddress: string): string {
   if (!/^0x[0-9a-fA-F]{40}$/.test(ethAddress)) {
     throw new Error(`Invalid Ethereum Address: ${ethAddress}`);
   }
 
   const pkHashHex = ethAddress.slice(2).toLowerCase(); // remove "0x"
-  const pkHashBytes = Buffer.from(pkHashHex, 'hex');   // 20 bytes
+  const pkHashBytes = hexToBytes(pkHashHex);           // 20 bytes
 
   const checksum = keccak_256(blake2b(pkHashBytes));
-  const tailBytes = Buffer.from(checksum.slice(0, 12));  // 12 bytes
+  const tailBytes = checksum.slice(0, 12);              // 12 bytes
 
-  const assetRaw = Buffer.concat([pkHashBytes, tailBytes]); // 32 bytes
+  const assetRaw = concatBytes(pkHashBytes, tailBytes); // 32 bytes
 
   return base58Encode(assetRaw);
 }

--- a/src/tools/assets/ethAsset2waves.ts
+++ b/src/tools/assets/ethAsset2waves.ts
@@ -1,0 +1,19 @@
+import { base58Encode } from '@waves/ts-lib-crypto';
+import { keccak_256 } from '@noble/hashes/sha3';
+import { blake2b } from '@noble/hashes/blake2b';
+
+export default function ethAsset2Waves(ethAddress: string): string {
+  if (!/^0x[0-9a-fA-F]{40}$/.test(ethAddress)) {
+    throw new Error(`Invalid Ethereum Address: ${ethAddress}`);
+  }
+
+  const pkHashHex = ethAddress.slice(2).toLowerCase(); // remove "0x"
+  const pkHashBytes = Buffer.from(pkHashHex, 'hex');   // 20 bytes
+
+  const checksum = keccak_256(blake2b(pkHashBytes));
+  const tailBytes = Buffer.from(checksum.slice(0, 12));  // 12 bytes
+
+  const assetRaw = Buffer.concat([pkHashBytes, tailBytes]); // 32 bytes
+
+  return base58Encode(assetRaw);
+}

--- a/test/tools/addresses/converter.spec.ts
+++ b/test/tools/addresses/converter.spec.ts
@@ -1,11 +1,20 @@
-import ethAddress2waves from '../../../src/tools/adresses/ethAddress2waves';
+import ethAsset2Waves from '../../../src/tools/assets/ethAsset2Waves';
+import wavesAsset2Eth from '../../../src/tools/assets/wavesAsset2Eth';
 
-test('eth 2 waves address', async () => {
-    const ethAddress = '0x11242d6ec6B50713026a3757cAeb027294C2242a';
-    const wavesAddress = '3EzjTrzQB57shiN4RwUi9ikC44FBGRzZ81G';
-    const chainId = 67; // C
+describe('Asset-ID conversion between Ethereum (EVM) and Waves', () => {
+  // ► Asset ID EVM (20 bytes, 0x…)
+  const ethAssetId   = '0x31f2bc7a100e9d8c4a200644c8bb7c7c277f56f8';
+  // ► Asset ID Waves (32 bytes -> Base58)
+  const wavesAssetId = '4MyexEQAxYdApQX2fAN2dc3VwPfKopRHs1EGyLHCCSVD';
 
-    const convertedAddress = ethAddress2waves(ethAddress, chainId);
+  test('ethAsset2Waves converte Asset ID EVM para Waves', () => {
+    const converted = ethAsset2Waves(ethAssetId);
+    expect(converted).toBe(wavesAssetId);
+  });
 
-    expect(convertedAddress).toBe(wavesAddress);
+  test('wavesAsset2Eth converte Asset ID Waves de volta para EVM', () => {
+    const converted = wavesAsset2Eth(wavesAssetId);
+    // ignorar diferenças de maiúsculas/minúsculas
+    expect(converted.toLowerCase()).toBe(ethAssetId.toLowerCase());
+  });
 });


### PR DESCRIPTION
added ethAsset2Waves, a function that converts a token's eth standard to a Waves standard. Use case: when the user clicks on view token details and is taken to /token/{id} in the explorer, this function can be used to convert the id to a Waves standard.